### PR TITLE
fix typo in additional resources of tutorial notebooks

### DIFF
--- a/projects/tutorials/pytorch_tutorial_mnist_VAE.ipynb
+++ b/projects/tutorials/pytorch_tutorial_mnist_VAE.ipynb
@@ -1355,7 +1355,7 @@
     "- [scikit-learn Python Library](https://scikit-learn.org/stable/index.html) (go-to for most ML algorithms besides neural networks)\n",
     "- [StatQuest YouTube Channel](https://www.youtube.com/c/joshstarmer)\n",
     "- [DeepLearningAI YouTube Channel](https://www.youtube.com/c/Deeplearningai/videos)\n",
-    "- [Towards Data Science](https://towardsdatascience.com/) (articles about data science and machine learning, some invlovling example blocks of code)\n",
+    "- [Towards Data Science](https://towardsdatascience.com/) (articles about data science and machine learning, some involving example blocks of code)\n",
     "- Advance searching [arxiv](https://arxiv.org/search/advanced) (e.g. search term \"machine learning\" in Abstract for Subject astro-ph) to see what others are doing currently\n",
     "- Google, YouTube, and Wikipedia in general\n",
     "- [Variational Autoencoder Original Paper](https://arxiv.org/abs/1312.6114)\n",

--- a/projects/tutorials/pytorch_tutorial_mnist_autoencoder.ipynb
+++ b/projects/tutorials/pytorch_tutorial_mnist_autoencoder.ipynb
@@ -1214,7 +1214,7 @@
     "- [scikit-learn Python Library](https://scikit-learn.org/stable/index.html) (go-to for most ML algorithms besides neural networks)\n",
     "- [StatQuest YouTube Channel](https://www.youtube.com/c/joshstarmer)\n",
     "- [DeepLearningAI YouTube Channel](https://www.youtube.com/c/Deeplearningai/videos)\n",
-    "- [Towards Data Science](https://towardsdatascience.com/) (articles about data science and machine learning, some invlovling example blocks of code)\n",
+    "- [Towards Data Science](https://towardsdatascience.com/) (articles about data science and machine learning, some involving example blocks of code)\n",
     "- Advance searching [arxiv](https://arxiv.org/search/advanced) (e.g. search term \"machine learning\" in Abstract for Subject astro-ph) to see what others are doing currently\n",
     "- Google, YouTube, and Wikipedia in general\n",
     "\n",

--- a/projects/tutorials/pytorch_tutorial_mnist_cnn.ipynb
+++ b/projects/tutorials/pytorch_tutorial_mnist_cnn.ipynb
@@ -1165,7 +1165,7 @@
     "- [scikit-learn Python Library](https://scikit-learn.org/stable/index.html) (go-to for most ML algorithms besides neural networks)\n",
     "- [StatQuest Youtube Channel](https://www.youtube.com/c/joshstarmer)\n",
     "- [DeepLearningAI YouTube Channel](https://www.youtube.com/c/Deeplearningai/videos)\n",
-    "- [Towards Data Science](https://towardsdatascience.com/) (articles about data science and machine learning, some invlovling example blocks of code)\n",
+    "- [Towards Data Science](https://towardsdatascience.com/) (articles about data science and machine learning, some involving example blocks of code)\n",
     "- Advance searching [arxiv](https://arxiv.org/search/advanced) (e.g. search term \"machine learning\" in Abstract for Subject astro-ph) to see what others are doing currently\n",
     "- Google, YouTube, and Wikipedia in general\n",
     "\n",

--- a/projects/tutorials/pytorch_tutorial_mnist_transfer_learning.ipynb
+++ b/projects/tutorials/pytorch_tutorial_mnist_transfer_learning.ipynb
@@ -1119,7 +1119,7 @@
     "- [scikit-learn Python Library](https://scikit-learn.org/stable/index.html) (go-to for most ML algorithms besides neural networks)\n",
     "- [StatQuest YouTube Channel](https://www.youtube.com/c/joshstarmer)\n",
     "- [DeepLearningAI YouTube Channel](https://www.youtube.com/c/Deeplearningai/videos)\n",
-    "- [Towards Data Science](https://towardsdatascience.com/) (articles about data science and machine learning, some invlovling example blocks of code)\n",
+    "- [Towards Data Science](https://towardsdatascience.com/) (articles about data science and machine learning, some involving example blocks of code)\n",
     "- Advance searching [arxiv](https://arxiv.org/search/advanced) (e.g. search term \"machine learning\" in Abstract for Subject astro-ph) to see what others are doing currently\n",
     "- Google, YouTube, and Wikipedia in general\n",
     "- Pretrained model papers:\n",


### PR DESCRIPTION
Fixed typo in all tutorial notebooks: invlovling --> involving